### PR TITLE
Set microseconds precision as the default value for DateTime columns

### DIFF
--- a/lib/cookpad_mysql_defaults.rb
+++ b/lib/cookpad_mysql_defaults.rb
@@ -1,4 +1,6 @@
 require "cookpad_mysql_defaults/mysql_table_default_options"
+require "cookpad_mysql_defaults/table_definition"
+require "cookpad_mysql_defaults/schema_statements"
 
 module CookpadMysqlDefaults
 end

--- a/lib/cookpad_mysql_defaults/schema_statements.rb
+++ b/lib/cookpad_mysql_defaults/schema_statements.rb
@@ -1,0 +1,32 @@
+module CookpadMysqlDefaults
+  module SchemaStatements
+    def add_column(table_name, column_name, type, **options)
+      if type == :datetime && !options.key?(:precision)
+        options[:precision] = 6
+      end
+
+      super
+    end
+
+    def create_table(table_name, **options)
+      if block_given?
+        super { |t| yield compatible_table_definition(t) }
+      else
+        super
+      end
+    end
+
+    private
+      def compatible_table_definition(t)
+        class << t
+          prepend TableDefinition
+        end
+        t
+      end
+  end
+end
+
+ActiveSupport.on_load(:active_record) do
+  require "active_record/connection_adapters/abstract_mysql_adapter"
+  ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.prepend(CookpadMysqlDefaults::SchemaStatements)
+end

--- a/lib/cookpad_mysql_defaults/table_definition.rb
+++ b/lib/cookpad_mysql_defaults/table_definition.rb
@@ -1,0 +1,11 @@
+module CookpadMysqlDefaults
+  module TableDefinition
+    def column(name, type, index: nil, **options)
+      if type == :datetime && !options.key?(:precision)
+        options[:precision] = 6
+      end
+
+      super
+    end
+  end
+end


### PR DESCRIPTION
Microsecond precision is now the standard behaviour for timestamps https://github.com/rails/rails/pull/34970, so it would good to extend this default to all datetimes by default. Microsecond precision is very useful for the following scenarios.

- Cursor pagination - When an entity supports cursor pagination, the order of the entities returned by pagination will be non-deterministic if there are duplicate rows. The chances of a duplicate row are minimal when using microsecond precision.
- Kafka - we previously configured all our Kafka topics to expose DateTime with microsecond based precision. Suppose a Kafka topic attribute is using a millisecond or second based precision column. In that case, it will append enough 0's onto the end of the DateTime to make it appear as a valid microsecond precision column. In this scenario, the formatting but loses the additional accuracy.
- Convention over configuration - it would be an improvement not having to worry about what columns can/can’t be used for cursor-based pagination or Kafka events and reduce cognitive load/gotchas if we apply microsecond precision to all entities.

The only downside that I’ve found is the fact that it will require more space. However, I don’t think this will be a big problem.

ref https://github.com/cookpad/global-web/pull/25808