### PR TITLE
Add Rubocop configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
 Gemfile.lock
+/.rubocop-*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+inherit_from:
+  - https://raw.githubusercontent.com/cookpad/global-style-guides/main/.rubocop.ruby.yml
+
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Declare your gem's dependencies in cookpad_mysql_defaults.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/cookpad_mysql_defaults.gemspec
+++ b/cookpad_mysql_defaults.gemspec
@@ -1,4 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 
 # Maintain your gem's version:
 require "cookpad_mysql_defaults/version"
@@ -10,12 +10,14 @@ Gem::Specification.new do |s|
   s.authors     = ["David Stosik", "Cookpad"]
   s.email       = ["david.stosik+git-noreply@gmail.com"]
   s.homepage    = "https://github.com/cookpad/cookpad-mysql-defaults"
-  s.summary     = %q{Cookpad Global's MySQL defaults}
-  s.description = %q{A gem that forces better MySQL table defaults to support Emojis and indexes on wider columns.}
+  s.summary     = "Cookpad Global's MySQL defaults"
+  s.description = "A gem that forces better MySQL table defaults to support Emojis and indexes on wider columns."
   s.license     = "MIT"
+  s.required_ruby_version = ">= 2.7"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "activerecord", ">= 4.2.5"
   s.add_dependency "activesupport", ">= 4.2.5"
+  s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/cookpad_mysql_defaults/schema_statements.rb
+++ b/lib/cookpad_mysql_defaults/schema_statements.rb
@@ -10,15 +10,16 @@ module CookpadMysqlDefaults
 
     def create_table(table_name, **options)
       if block_given?
-        super { |t| yield compatible_table_definition(t) }
+        super { |table_definition| yield compatible_table_definition(table_definition) }
       else
         super
       end
     end
 
     private
-      def compatible_table_definition(t)
-        class << t
+
+      def compatible_table_definition(table_definition)
+        class << table_definition
           prepend TableDefinition
         end
         t

--- a/lib/cookpad_mysql_defaults/version.rb
+++ b/lib/cookpad_mysql_defaults/version.rb
@@ -1,3 +1,3 @@
 module CookpadMysqlDefaults
-  VERSION = '0.3.0'
+  VERSION = "0.3.0".freeze
 end


### PR DESCRIPTION
This PR adds Rubocop configuration which inherits from `cookpad/global-style-guides`, and also fix any outstanding violations to the style guide.