### PR TITLE
Stop loading datetime precision patch on Active Record 7+

### DIFF
--- a/lib/cookpad_mysql_defaults.rb
+++ b/lib/cookpad_mysql_defaults.rb
@@ -1,6 +1,8 @@
 require "cookpad_mysql_defaults/mysql_table_default_options"
-require "cookpad_mysql_defaults/table_definition"
-require "cookpad_mysql_defaults/schema_statements"
 
-module CookpadMysqlDefaults
+# Only load datetime precision patch on Active Record 6.1 or below as
+# datetime(6) is now a default. See https://github.com/rails/rails/pull/42297
+if ActiveRecord::VERSION::MAJOR < 7
+  require "cookpad_mysql_defaults/table_definition"
+  require "cookpad_mysql_defaults/schema_statements"
 end


### PR DESCRIPTION
This is an alternate take to #3

This PR keeps `datetime(6)` precision patch as-is, but only load the patch when the gem is loaded with Active Record version less than 7.

Close #3